### PR TITLE
Disable NEON acceleration on ARM since it's broken apparently

### DIFF
--- a/Makefile.gnu
+++ b/Makefile.gnu
@@ -15,7 +15,7 @@ LIBRARIES = -lstdc++
 
 MODULES = $(SRCS:.c=.o)
 MODULES := $(MODULES:.cpp=.o)
-CFLAGS ?= -O3 -fPIC -fexceptions -fvisibility=hidden
+CFLAGS ?= -DPNG_ARM_NEON_OPT=0 -O3 -fPIC -fexceptions -fvisibility=hidden
 # OpenJPEG
 CFLAGS += -DOPJ_STATIC 
 # LibRaw


### PR DESCRIPTION
After doing some research, it appears that ARM NEON acceleration for PNGs is just broken(?) apparently. In any case, trying to build this repository on ARM systems with NEON acceleration results in a missing symbol when trying to run the headless. (Tested on Ampere A1 ARM) 

Simply disabling the neon acceleration fixes this and appears inconsequential to the usage of the library. Especially since everything gets converted to WebP and the NEON acceleration is particular to the PNG code.