### PR TITLE
Improve Linux build backwards compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   buildLinux:
     runs-on: ubuntu-latest
-    container: debian:buster
+    container: debian:buster # Using debian buster environment for glibc backwards compatibility, see https://github.com/Yellow-Dog-Man/FreeImage/pull/12
     steps:
       - uses: actions/checkout@v4
       - name: Build Native Linux

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,14 @@ on:
 jobs:
   buildLinux:
     runs-on: ubuntu-latest
+    container: debian:buster
     steps:
       - uses: actions/checkout@v4
       - name: Build Native Linux
-        run: make all
+        run: |
+          apt update
+          apt install -y make gcc g++ unzip
+          make all
       - uses: actions/upload-artifact@v4
         with:
           path: Dist/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   buildLinux:
     runs-on: ubuntu-latest
-    container: debian:buster
+    container: debian:buster # Using debian buster environment for glibc backwards compatibility, see https://github.com/Yellow-Dog-Man/FreeImage/pull/12
     env:
       VERSION: ${{ github.event.release.tag_name }}
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,12 +9,16 @@ on:
 jobs:
   buildLinux:
     runs-on: ubuntu-latest
+    container: debian:buster
     env:
       VERSION: ${{ github.event.release.tag_name }}
     steps:
       - uses: actions/checkout@v4
       - name: Build Native Linux
-        run: make all
+        run: |
+          apt update
+          apt install -y make gcc g++ unzip
+          make all
       - uses: actions/upload-artifact@v4
         with:
           path: Dist/


### PR DESCRIPTION
This makes automated Linux builds use a lower glibc version by running the GitHub action inside a Debian buster container. The resulting binary requires at minimum GLIBCXX_3.4.21.

Closes #10.