### PR TITLE
feat(exif): Enable EXIF Writing using FIMD_EXIF_RAW

### DIFF
--- a/Wrapper/FreeImage.NET/cs/Library/Classes/ImageMetadata.cs
+++ b/Wrapper/FreeImage.NET/cs/Library/Classes/ImageMetadata.cs
@@ -60,14 +60,15 @@ namespace FreeImageAPI.Metadata
 		/// <param name="dib">Handle to a FreeImage bitmap.</param>
 		public ImageMetadata(FIBITMAP dib) : this(dib, false) { }
 
-		/// <summary>
-		/// Initializes a new instance based on the specified <see cref="FIBITMAP"/>,
-		/// showing or hiding empry models.
-		/// </summary>
-		/// <param name="dib">Handle to a FreeImage bitmap.</param>
-		/// <param name="hideEmptyModels">When <b>true</b>, empty metadata models
+        /// <summary>
+        /// Initializes a new instance based on the specified <see cref="FIBITMAP"/>,
+        /// showing or hiding empry models.
+        /// </summary>
+        /// <param name="dib">Handle to a FreeImage bitmap.</param>
+        /// <param name="hideEmptyModels">When <b>true</b>, empty metadata models
 		/// will be hidden until a tag to this model is added.</param>
-		public ImageMetadata(FIBITMAP dib, bool hideEmptyModels)
+        /// <param name="includeRaw">When <b>true</b>, include raw byte access to EXIF, <see cref="MDM_EXIF_RAW"/>.
+        public ImageMetadata(FIBITMAP dib, bool hideEmptyModels, bool includeRaw = false)
 		{
 			if (dib.IsNull) throw new ArgumentNullException("dib");
 			data = new List<MetadataModel>(FreeImage.FREE_IMAGE_MDMODELS.Length);
@@ -86,6 +87,10 @@ namespace FreeImageAPI.Metadata
 			data.Add(new MDM_IPTC(dib));
 			data.Add(new MDM_NODATA(dib));
 			data.Add(new MDM_XMP(dib));
+
+            // This is based on: https://sourceforge.net/p/freeimage/discussion/36111/thread/2d087f91/
+            if (includeRaw)
+				data.Add(new MDM_EXIF_RAW(dib));
 		}
 
 		/// <summary>

--- a/Wrapper/FreeImage.NET/cs/Library/Classes/MetadataModel.cs
+++ b/Wrapper/FreeImage.NET/cs/Library/Classes/MetadataModel.cs
@@ -148,7 +148,7 @@ namespace FreeImageAPI.Metadata
 		/// which will remove all tags of this model from the bitmap.
 		/// </summary>
 		/// <returns>Returns true on success, false on failure.</returns>
-		public bool DestoryModel()
+		public bool DestroyModel()
 		{
 			return FreeImage.SetMetadata(Model, dib, null, FITAG.Zero);
 		}

--- a/Wrapper/FreeImage.NET/cs/Library/Classes/MetadataModels.cs
+++ b/Wrapper/FreeImage.NET/cs/Library/Classes/MetadataModels.cs
@@ -386,6 +386,34 @@ namespace FreeImageAPI.Metadata
 
     /// <summary>
     /// Represents a collection of all tags contained in the metadata model
+    /// <see cref="FREE_IMAGE_MDMODEL.FIMD_EXIF_RAW"/>.
+    /// </summary>
+    /// <remarks>
+    /// FreeImage keeps two separate copies of Exif Metadata in memory. 
+    /// One is used/found in <see cref="MDM_EXIF_MAIN"/> and its extensions(e.g. <see cref="MDM_EXIF_GPS"/>).
+    /// Another one is used when files are actually written that support the EXIF Format. In some cases you want to access, the raw data.
+    /// A good example of this is when using <see cref="MetadataModel.DestroyModel"/> to wipe EXIF data on an image, 
+    /// that you want persisted if that file is exported again from FreeImage.
+    /// </remarks>
+    public class MDM_EXIF_RAW : MetadataModel
+    {
+        /// <summary>
+        /// Initializes a new instance of this class.
+        /// </summary>
+        /// <param name="dib">Handle to a FreeImage bitmap.</param>
+        public MDM_EXIF_RAW(FIBITMAP dib) : base(dib) { }
+
+        /// <summary>
+        /// Retrieves the datamodel that this instance represents.
+        /// </summary>
+        public override FREE_IMAGE_MDMODEL Model
+        {
+            get { return FREE_IMAGE_MDMODEL.FIMD_EXIF_RAW; }
+        }
+    }
+
+    /// <summary>
+    /// Represents a collection of all tags contained in the metadata model
     /// <see cref="FREE_IMAGE_MDMODEL.FIMD_EXIF_EXIF"/>.
     /// </summary>
     public class MDM_EXIF_EXIF : MetadataModel

--- a/Wrapper/FreeImage.NET/cs/Library/Enumerations/FREE_IMAGE_MDMODEL.cs
+++ b/Wrapper/FreeImage.NET/cs/Library/Enumerations/FREE_IMAGE_MDMODEL.cs
@@ -87,6 +87,12 @@ namespace FreeImageAPI
 		/// <summary>
 		/// Used to attach other metadata types to a dib
 		/// </summary>
-		FIMD_CUSTOM = 10
+		FIMD_CUSTOM = 10,
+
+        /// <summary>
+        /// Raw access to EXIF.
+        /// </summary>
+        /// <remarks>This is based on: https://sourceforge.net/p/freeimage/discussion/36111/thread/2d087f91/</remarks>
+        FIMD_EXIF_RAW = 11
 	}
 }


### PR DESCRIPTION
FreeImage keeps two separate copies of Exif Metadata in memory:
- One is used/found in MDM_EXIF_MAIN and its extensions(e.g. MDM_EXIF_GPS).
- Another one is used when files are actually written that support the EXIF Format.
- In some cases you want to access, the raw data.
- A good example of this is when using MetadataModel.DestroyModel to wipe EXIF data on an image that you wanted persisted if that file is exported again from FreeImage.
- DestoryModel was also corrected to DestroyModel, this will result in a breaking change version but that's worth it!

With this you can use the following to clear and persist that "clearing" of the exif data on a FreeImage image:
```cs
ImageMetadata imageMetadata = new ImageMetadata(dib, true, true);
var model = imageMetadata[FREE_IMAGE_MDMODEL.FIMD_EXIF_RAW];
model.DestroyModel();
```

When you then write that subsequent image to a file, the file will not contain any EXIF data!

This is based on:
- https://sourceforge.net/p/freeimage/discussion/36111/thread/2d087f91/ where i discovered FIMD_EXIF_RAW
- https://sourceforge.net/p/freeimage/discussion/36111/thread/8233f5bc/ where I learnt how you might use it.

As this change doesn't touch the native library, you won't need to compile that again. This is a purely .NET change. -