### PR TITLE
Slightly refactor/fix/change/improve WebP config

### DIFF
--- a/Source/FreeImage/PluginWebP.cpp
+++ b/Source/FreeImage/PluginWebP.cpp
@@ -489,6 +489,7 @@ EncodeImage(FIMEMORY *hmem, FIBITMAP *dib, int flags) {
 			// quality/speed trade-off (0=fast, 6=slower-better)
 			config.method = 5;
 			//config.autofilter = 1;	// improves lossy quality but is NOTICEABLY slower
+			config.use_sharp_yuv = 1;	// "config.preprocessing = 4;" is the old/alternative way to activate SharpYUV. NOTE: in some rare'ish cases SharpYUV can cause some colors to be more red then they should be
 
 			// quality is between 1 (smallest file) and 100 (biggest) - default to 75
 			config.quality = (float)(flags & 0x7F);

--- a/Source/FreeImage/PluginWebP.cpp
+++ b/Source/FreeImage/PluginWebP.cpp
@@ -471,20 +471,25 @@ EncodeImage(FIMEMORY *hmem, FIBITMAP *dib, int flags) {
 		WebPConfigInit(&config);
 
 		config.thread_level = 1;
-		// quality/speed trade-off (0=fast, 6=slower-better)
-		config.method = 0;
 
 		config.exact = (flags & WEBP_EXACT) == WEBP_EXACT;
 
 		if((flags & WEBP_LOSSLESS) == WEBP_LOSSLESS) {
 			// lossless encoding
 			config.lossless = 1;
-			config.quality = 100;
+			// size/speed trade-off (method 0 and quality 0 = lowest effort but largest file-size while method 6 and quality 100 = highest effort and smallest file-size. NOTE: "quality" in this context is NOT related to anything visual)
+			config.method = 3;
+			config.quality = 30;
+
 			picture.use_argb = 1;
 
 		} else if((flags & 0x7F) > 0) {
 			// lossy encoding
 			config.lossless = 0;
+			// quality/speed trade-off (0=fast, 6=slower-better)
+			config.method = 5;
+			//config.autofilter = 1;	// improves lossy quality but is NOTICEABLY slower
+
 			// quality is between 1 (smallest file) and 100 (biggest) - default to 75
 			config.quality = (float)(flags & 0x7F);
 			if(config.quality > 100) {

--- a/Source/FreeImage/PluginWebP.cpp
+++ b/Source/FreeImage/PluginWebP.cpp
@@ -478,8 +478,8 @@ EncodeImage(FIMEMORY *hmem, FIBITMAP *dib, int flags) {
 			// lossless encoding
 			config.lossless = 1;
 			// size/speed trade-off (method 0 and quality 0 = lowest effort but largest file-size while method 6 and quality 100 = highest effort and smallest file-size. NOTE: "quality" in this context is NOT related to anything visual)
-			config.method = 3;
-			config.quality = 30;
+			config.method = 4;
+			config.quality = 50;
 
 			picture.use_argb = 1;
 

--- a/Source/FreeImage/PluginWebP.cpp
+++ b/Source/FreeImage/PluginWebP.cpp
@@ -478,8 +478,8 @@ EncodeImage(FIMEMORY *hmem, FIBITMAP *dib, int flags) {
 			// lossless encoding
 			config.lossless = 1;
 			// size/speed trade-off (method 0 and quality 0 = lowest effort but largest file-size while method 6 and quality 100 = highest effort and smallest file-size. NOTE: "quality" in this context is NOT related to anything visual)
-			config.method = 4;
-			config.quality = 50;
+			config.method = 2;
+			config.quality = 25;
 
 			picture.use_argb = 1;
 


### PR DESCRIPTION
`PluginWebP.cpp` has a fundamentally flawed understanding of how the config value "quality" interacts with lossless encoding in libwebp and this commit solves that along with some other minor changes.


the method and "quality" values in this pull request equate to `-z 2` ~~`-z 5` (was `-z 3` in this pull request originally) in cwebp/libwebp (the default is `-z 6` which is lower then FreeImage's default).~~ for more information see these links:
https://developers.google.com/speed/webp/docs/cwebp
https://github.com/webmproject/libwebp/blob/874069042ead095f8a8d6bdd35b9b145ce80af43/src/enc/config_enc.c#L136

~~If the encoding ends up being considered too slow then simply change the values to a lower preset as defined in the second URL I linked (you can technically set them to whatever but it's cleaner to have them just match one of the `-z` presets)~~