### PR TITLE
Improve WebP settings

### DIFF
--- a/Source/FreeImage/PluginWebP.cpp
+++ b/Source/FreeImage/PluginWebP.cpp
@@ -475,22 +475,23 @@ EncodeImage(FIMEMORY *hmem, FIBITMAP *dib, int flags) {
 		config.exact = (flags & WEBP_EXACT) == WEBP_EXACT;
 
 		if((flags & WEBP_LOSSLESS) == WEBP_LOSSLESS) {
-			// lossless encoding
+			// Lossless encoding
 			config.lossless = 1;
 			// Size/speed trade-off. Method 0 quality 0 = fastest but largest file-size. Method 6 quality 100 = slowest and smallest file-size.
-			// NOTE: "quality" in this context is NOT related to anything visual
+			// NOTE: "quality" in this context is NOT related to anything visual, it purely effects time spent encoding.
 			config.method = 0;
 			config.quality = 0;
 			picture.use_argb = 1;
 
 		} else if((flags & 0x7F) > 0) {
-			// lossy encoding
+			// Lossy encoding
 			config.lossless = 0;
-			// Quality/speed trade-off (0=fast, 6=slower-better)
+			// Quality/size/speed trade-off (0=fast, 6=slower-better)
 			config.method = 5;
-			// Improves color accuracy. NOTE: in some rare cases SharpYUV can cause some colors to be more red then they should be.
+			// Improves color accuracy for the forced 4:2:0 color subsampling in lossy WebP.
+			// NOTE: In rare cases SharpYUV can cause some colors to become more red.
 			config.use_sharp_yuv = 1;
-			// quality is between 1 (smallest file) and 100 (biggest) - default to 75
+			// Quality is between 0 (smallest file) and 100 (biggest) - default to 75
 			config.quality = (float)(flags & 0x7F);
 			if(config.quality > 100) {
 				config.quality = 100;

--- a/Source/FreeImage/PluginWebP.cpp
+++ b/Source/FreeImage/PluginWebP.cpp
@@ -471,20 +471,25 @@ EncodeImage(FIMEMORY *hmem, FIBITMAP *dib, int flags) {
 		WebPConfigInit(&config);
 
 		config.thread_level = 1;
-		// quality/speed trade-off (0=fast, 6=slower-better)
-		config.method = 0;
 
 		config.exact = (flags & WEBP_EXACT) == WEBP_EXACT;
 
 		if((flags & WEBP_LOSSLESS) == WEBP_LOSSLESS) {
 			// lossless encoding
 			config.lossless = 1;
-			config.quality = 100;
+			// Size/speed trade-off. Method 0 quality 0 = fastest but largest file-size. Method 6 quality 100 = slowest and smallest file-size.
+			// NOTE: "quality" in this context is NOT related to anything visual
+			config.method = 0;
+			config.quality = 0;
 			picture.use_argb = 1;
 
 		} else if((flags & 0x7F) > 0) {
 			// lossy encoding
 			config.lossless = 0;
+			// Quality/speed trade-off (0=fast, 6=slower-better)
+			config.method = 5;
+			// Improves color accuracy. NOTE: in some rare cases SharpYUV can cause some colors to be more red then they should be.
+			config.use_sharp_yuv = 1;
 			// quality is between 1 (smallest file) and 100 (biggest) - default to 75
 			config.quality = (float)(flags & 0x7F);
 			if(config.quality > 100) {
@@ -701,4 +706,3 @@ InitWEBP(Plugin *plugin, int format_id) {
 	plugin->supports_icc_profiles_proc = SupportsICCProfiles;
 	plugin->supports_no_pixels_proc = SupportsNoPixels;
 }
-

--- a/Source/FreeImage/PluginWebP.cpp
+++ b/Source/FreeImage/PluginWebP.cpp
@@ -477,21 +477,25 @@ EncodeImage(FIMEMORY *hmem, FIBITMAP *dib, int flags) {
 		if((flags & WEBP_LOSSLESS) == WEBP_LOSSLESS) {
 			// Lossless encoding
 			config.lossless = 1;
-			// Size/speed trade-off. Method 0 quality 0 = fastest but largest file-size. Method 6 quality 100 = slowest and smallest file-size.
-			// NOTE: "quality" in this context is NOT related to anything visual, it purely effects time spent encoding.
-			config.method = 0;
-			config.quality = 0;
+			// Size/speed trade-off. Method 0 quality 0 = fastest but largest. Method 6 quality 100 = slowest and smallest
+			// NOTE: "quality" when lossless is enabled is NOT related to anything visual, it purely effects time spent encoding
+			config.method = 1;
+			config.quality = 20;
+			// Make sure lossless is actually lossless
 			picture.use_argb = 1;
+			config.exact = 1;
 
 		} else if((flags & 0x7F) > 0) {
 			// Lossy encoding
 			config.lossless = 0;
 			// Quality/size/speed trade-off (0=fast, 6=slower-better)
-			config.method = 5;
-			// Improves color accuracy for the forced 4:2:0 color subsampling in lossy WebP.
-			// NOTE: In rare cases SharpYUV can cause some colors to become more red.
+			// NOTE: The slowest lossy speed matches the fastest lossless speed
+			config.method = 6;
+			// Improves color accuracy for the forced 4:2:0 color subsampling in lossy WebP
+			// NOTE: In rare cases SharpYUV can cause some colors to become more red
 			config.use_sharp_yuv = 1;
-			// Quality is between 0 (smallest file) and 100 (biggest) - default to 75
+			// Quality is between 0 (smallest file) and 100 (biggest) - defaults to 75
+			// NOTE: Using method 6 above gives enough wiggle room to raise quality, consider using 80-85
 			config.quality = (float)(flags & 0x7F);
 			if(config.quality > 100) {
 				config.quality = 100;


### PR DESCRIPTION
~~Increases lossless encoding speed tenfold and improves lossy quality while halving filesizes.~~
Last commit only makes it 2x faster but also 20% smaller, to avoid edge cases where the image was larger.
Rebase of #17 due to messy communication and commit history.

To fix #20, the JPEG and PNG changes need to be implemented within FrooxEngine, which is being discussed in https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/4953 and my comment in https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/874#issuecomment-3115357587.