### PR TITLE
Fixes for GCC 14/15 & Musl

### DIFF
--- a/Source/FreeImage/PluginPSD.cpp
+++ b/Source/FreeImage/PluginPSD.cpp
@@ -127,7 +127,7 @@ Load(FreeImageIO *io, fi_handle handle, int page, int flags, void *data) {
 static BOOL DLL_CALLCONV
 Save(FreeImageIO *io, FIBITMAP *dib, fi_handle handle, int page, int flags, void *data) {
 	if(!handle) {
-		return NULL;
+		return FALSE;
 	}
 	try {
 		psdParser parser;

--- a/Source/LibJXR/image/decode/segdec.c
+++ b/Source/LibJXR/image/decode/segdec.c
@@ -29,6 +29,17 @@
 #include "strcodec.h"
 #include "decode.h"
 
+#ifdef _MSC_VER
+
+#include <stdlib.h>
+#define bswap_32(x) _byteswap_ulong(x)
+
+#else
+
+#include <byteswap.h>
+
+#endif
+
 #ifdef MEM_TRACE
 #define TRACE_MALLOC    1
 #define TRACE_NEW       0
@@ -61,9 +72,9 @@ static U32 _FORCEINLINE _load4(void* pv)
     U32  v;
     v = ((U16 *) pv)[0];
     v |= ((U32)((U16 *) pv)[1]) << 16;
-    return _byteswap_ulong(v);
+    return bswap_32(v);
 #else // _M_IA64
-    return _byteswap_ulong(*(U32*)pv);
+    return bswap_32(*(U32*)pv);
 #endif // _M_IA64
 #endif // _BIG__ENDIAN_
 }

--- a/Source/LibJXR/jxrgluelib/JXRGlueJxr.c
+++ b/Source/LibJXR/jxrgluelib/JXRGlueJxr.c
@@ -27,8 +27,8 @@
 //
 //*@@@---@@@@******************************************************************
 #include <limits.h>
+#include <wchar.h>
 #include <JXRGlue.h>
-
 
 static const char szHDPhotoFormat[] = "<dc:format>image/vnd.ms-photo</dc:format>";
 const U32 IFDEntryTypeSizes[] = { 0, 1, 1, 2, 4, 8, 1, 1, 2, 4, 8, 4, 8 };

--- a/Source/ZLib/gzguts.h
+++ b/Source/ZLib/gzguts.h
@@ -136,6 +136,10 @@
 #  endif
 #endif
 
+#ifdef linux
+#include <unistd.h>
+#endif
+
 /* provide prototypes for these when building zlib without LFS */
 #if !defined(_LARGEFILE64_SOURCE) || _LFS64_LARGEFILE-0 == 0
     ZEXTERN gzFile ZEXPORT gzopen64 OF((const char *, const char *));


### PR DESCRIPTION
This PR fixes a couple build errors that cause builds to fail on GCC 14 and 15, some with/without musl. Most are caused by missing includes, either by mistake or in the case of zlib, autoconf not being called and integrated as part of the build process.

Tested build hosts:
- Arch Linux x64 on GCC 15.2.1 (glibc)
- Alpine Linux arm64 on GCC 14.2.0 (musl)

